### PR TITLE
Add support for Haiku

### DIFF
--- a/autoload/fontsize.vim
+++ b/autoload/fontsize.vim
@@ -27,6 +27,9 @@ let fontsize#regex_kde = '\(.\{-}\/\)\(\d\+\)\(.*\)'
 " TODO For now, just taking the first string of digits.
 let fontsize#regex_x11 = '\(.\{-}-\)\(\d\+\)\(.*\)'
 
+" gui_haiku: Terminus (TTF)/Medium/20
+let fontsize#regex_haiku = '\(.*/.*/\)\([0-9.]\+\)\(\)$'
+
 " gui_other: Courier_New:h11:cDEFAULT
 let fontsize#regex_other = '\(.\{-}:h\)\(\d\+\)\(.*\)'
 
@@ -38,6 +41,8 @@ elseif has("gui_kde")
     let s:regex = fontsize#regex_kde
 elseif has("x11")
     let s:regex = fontsize#regex_x11
+elseif has("haiku")
+    let s:regex = fontsize#regex_haiku
 else
     let s:regex = fontsize#regex_other
 endif

--- a/doc/fontsize.txt
+++ b/doc/fontsize.txt
@@ -1,5 +1,5 @@
 *fontsize.txt*   Plugin for modifying guifont size
-*fontsize*       Version 0.5.0
+*fontsize*       Version 0.5.1
 
 ==============================================================================
 1.  Introduction                                    |fontsize-intro|
@@ -166,6 +166,10 @@ the font names.  For example, on Chinese Windows XP, the fonts are encoded in
 ===============================================================================
 5.  ChangeLog                                       *fontsize-changelog*
 
+Version 0.5.1    Date    2025-10-26                 *fontsize-changelog-0.5.1*
+
+  - Add support for Haiku.
+
 Version 0.5.0    Date    2023-08-19                 *fontsize-changelog-0.5.0*
 
   - Add support for Neovim GUIs (at least nvim-qt and neovide).
@@ -252,6 +256,7 @@ Contributors in chronological order:
 - hfs
 - Ingo Karkat
 - Anatolii Sakhnik
+- cos
 
 ===============================================================================
 vim:sts=2:et:ai:tw=78:fo=tcq2:ft=help:


### PR DESCRIPTION
Starting with vim 8.2.0320, Haiku <https://www.haiku-os.org/> support is included. The font string differs from other platforms. This commit adds a regex to match them.